### PR TITLE
Corrige os IDs do Preprints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'requests>=2.18.1',
-    'lxml==3.7.2',
+    'lxml==4.5.0',
     'raven==6.1.0',
     'articlemetaapi==1.23.0',
     'accessstatsapi==1.2.0',

--- a/tests/test_preprint.py
+++ b/tests/test_preprint.py
@@ -272,6 +272,7 @@ class TestFulltexts(unittest.TestCase):
                     http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
                     <dc:identifier>https://preprints.scielo.org/index.php/scielo/preprint/view/7</dc:identifier>
                     <dc:identifier>10.1590/scielopreprints.7</dc:identifier>
+                    <dc:language>eng</dc:language>
                 </oai_dc:dc>
             </metadata>
         </record>
@@ -342,6 +343,38 @@ class TestAbstract(unittest.TestCase):
         self.assertIsNotNone(xml.find(".//field[@name='ab_es']"))
         self.assertIsNotNone(xml.find(".//field[@name='ab_pt']"))
         self.assertIsNotNone(xml.find(".//field[@name='ab_fr']"))
+
+
+# <field name="AvailableLanguages">en</field>
+# <field name="AvailableLanguages">pt</field>
+class TestAvailableLanguages(unittest.TestCase):
+
+    def test_transform(self):
+        text = """<root xmlns:dc="http://www.openarchives.org/OAI/2.0/provenance">
+        <record>
+            <metadata>
+                <oai_dc:dc
+                    xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                    xmlns:dc="http://purl.org/dc/elements/1.1/"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                    http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:description xml:lang="es-ES">COVID-19 in Brazil: advantages of a socialized unified health system and preparation to contain cases</dc:description>
+                    <dc:description xml:lang="pt-BR">COVID-19 in Brazil: advantages of a socialized unified health system and preparation to contain cases</dc:description>
+                    <dc:description xml:lang="fr-FR">COVID-19 in Brazil: advantages of a socialized unified health system and preparation to contain cases</dc:description>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+        </root>
+        """
+        xml = ET.Element("doc")
+        raw = ET.fromstring(text)
+        data = raw, xml
+        raw, xml = pipeline_xml.AvailableLanguages().transform(data)
+
+        result = xml.findall('./field[@name="available_languages"]')
+
+        self.assertEqual(['es', 'fr', 'pt'], sorted([i.text for i in result]))
 
 
 # <field name="keyword_*"></field>

--- a/tests/test_preprint.py
+++ b/tests/test_preprint.py
@@ -2,7 +2,7 @@
 import unittest
 from lxml import etree as ET
 
-import pipeline_xml
+from updatepreprint import pipeline_xml
 
 
 namespaces = {'dc': 'http://purl.org/dc/elements/1.1/',

--- a/tests/test_preprint.py
+++ b/tests/test_preprint.py
@@ -51,7 +51,7 @@ class TestDocumentID(unittest.TestCase):
         raw = ET.fromstring(text)
         data = raw, xml
         raw, xml = pipeline_xml.DocumentID().transform(data)
-        self.assertEqual(xml.find(".//field[@name='id']").text, '10.1590/scielopreprints.7')
+        self.assertEqual(xml.find(".//field[@name='id']").text, 'preprint_7')
 
 
 # <field name="ur">art-S1980-993X2015000200234</field>
@@ -420,8 +420,9 @@ class TestPermission(unittest.TestCase):
         raw = ET.fromstring(text)
         data = raw, xml
         raw, xml = pipeline_xml.Permission().transform(data)
+
         self.assertEqual(
-            xml.find(".//field[@name='use_license']").text,
+            xml.find(".//field[@name='use_license_ur']").text,
             "https://creativecommons.org/licenses/by/4.0"
         )
         self.assertEqual(

--- a/tests/test_xmlpipeline.py
+++ b/tests/test_xmlpipeline.py
@@ -99,7 +99,7 @@ class ExportTests(unittest.TestCase):
         xmlarticle = pipeline_xml.SetupDocument()
         raw, xml = xmlarticle.transform(data)
 
-        self.assertEqual('<doc />', ET.tostring(xml))
+        self.assertEqual(b'<doc/>', ET.tostring(xml))
 
     def test_is_citable_false(self):
 
@@ -702,7 +702,7 @@ class ExportTests(unittest.TestCase):
 
         result = [i.text for i in xml.findall('./field[@name="sponsor"]')]
 
-        self.assertEqual([u'Fundação de Amparo à Pesquisa do Estado de Minas Gerais', u'Ministério da Saúde', u'Conselho Nacional de Desenvolvimento Científico e Tecnológico'], result)
+        self.assertEqual(sorted([u'Fundação de Amparo à Pesquisa do Estado de Minas Gerais', u'Ministério da Saúde', u'Conselho Nacional de Desenvolvimento Científico e Tecnológico']), sorted(result))
 
     def test_xml_document_sponsor_without_data_pipe(self):
 

--- a/tests/test_xmlpipeline.py
+++ b/tests/test_xmlpipeline.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 import unittest
-import xml.etree.ElementTree as ET
+
+from lxml import etree as ET
 import json
 import os
 
-from lxml import etree
 from xylose.scielodocument import Article
 
 from updatesearch import pipeline_xml

--- a/updatepreprint/pipeline_xml.py
+++ b/updatepreprint/pipeline_xml.py
@@ -220,8 +220,31 @@ class Abstract(plumber.Pipe):
                 lang = lang.split("-")[0]
             field = ET.Element('field')
             field.text = item.text
-            field.set('name', 'ab_{}'.format(lang))
+            field.set('name', 'ab_{}'.format(standardize_tag(lang)))
             xml.find('.').append(field)
+        return data
+
+
+# <field name="available_languages"  type="string" indexed="true" stored="true"  multiValued="true"/>
+class AvailableLanguages(plumber.Pipe):
+
+    def transform(self, data):
+        raw, xml = data
+        xpath = ".//dc:description"
+
+        langs = set()
+        for item in raw.findall(xpath, namespaces=ns):
+            lang = item.get('{http://www.w3.org/XML/1998/namespace}lang')
+            if "-" in lang:
+                lang = lang.split("-")[0]
+            langs.add(standardize_tag(lang))
+
+        for language in langs:
+            field = ET.Element('field')
+            field.text = language
+            field.set('name', 'available_languages')
+            xml.find('.').append(field)
+
         return data
 
 

--- a/updatepreprint/pipeline_xml.py
+++ b/updatepreprint/pipeline_xml.py
@@ -68,9 +68,9 @@ class DocumentID(plumber.Pipe):
         raw, xml = data
 
         for identifier in raw.findall(xpath, namespaces=ns):
-            if not identifier.text.startswith('http'):
+            if identifier.text.startswith('http'):
                 field = ET.Element('field')
-                field.text = identifier.text
+                field.text = "preprint_%s" % (identifier.text.split('/')[-1])
                 field.set('name', 'id')
                 xml.find('.').append(field)
 

--- a/updatepreprint/updatepreprint.py
+++ b/updatepreprint/updatepreprint.py
@@ -95,6 +95,7 @@ class UpdatePreprint(object):
             pipeline_xml.Titles(),
             pipeline_xml.Abstract(),
             pipeline_xml.Authors(),
+            pipeline_xml.AvailableLanguages(),
 
             pipeline_xml.TearDown()
         )

--- a/updatepreprint/updatepreprint.py
+++ b/updatepreprint/updatepreprint.py
@@ -136,9 +136,10 @@ class UpdatePreprint(object):
                 sys.exit(0)
             else:
 
-                for record in records:
+                for i, record in enumerate(records):
                     try:
                         xml = self.pipeline_to_xml(record.xml)
+                        print("Indexing record %s with oai id: %s" % (i, record.header.identifier))
                         self.solr.update(xml, commit=True)
                     except ValueError as e:
                         print("ValueError: {0}".format(e))

--- a/updatepreprint/updatepreprint.py
+++ b/updatepreprint/updatepreprint.py
@@ -7,8 +7,6 @@ import os
 import sys
 import time
 import argparse
-import logging
-import logging.config
 import textwrap
 from datetime import datetime, timedelta
 
@@ -19,39 +17,6 @@ from updatepreprint import pipeline_xml
 from sickle import Sickle
 
 from SolrAPI import Solr
-
-logger = logging.getLogger(__name__)
-
-LOGGING_LEVEL = os.environ.get('LOGGING_LEVEL', 'DEBUG')
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': True,
-
-    'formatters': {
-        'console': {
-            'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            'datefmt': '%H:%M:%S',
-            },
-        },
-    'handlers': {
-        'console': {
-            'level': LOGGING_LEVEL,
-            'class': 'logging.StreamHandler',
-            'formatter': 'console'
-            }
-        },
-    'loggers': {
-        '': {
-            'handlers': ['console'],
-            'level': LOGGING_LEVEL,
-            'propagate': False,
-            },
-        'updatepreprint.updatepreprint': {
-            'level': LOGGING_LEVEL,
-            'propagate': True,
-        },
-    }
-}
 
 
 class UpdatePreprint(object):
@@ -81,18 +46,6 @@ class UpdatePreprint(object):
                         dest='oai_url',
                         default="http://preprints.scielo.org/index.php/scielo/oai",
                         help='OAI URL, processing try to get the variable from environment ``OAI_URL`` otherwise use --oai_url to set the oai_url (preferable).')
-
-    parser.add_argument('--logging_level', '-l',
-                        default=LOGGING_LEVEL,
-                        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-                        help='Logggin level')
-
-    args = parser.parse_args()
-    LOGGING['handlers']['console']['level'] = args.logging_level
-    for lg, content in LOGGING['loggers'].items():
-        content['level'] = args.logging_level
-
-    logging.config.dictConfig(LOGGING)
 
     parser.add_argument('-v', '--version',
                         action='version',
@@ -166,7 +119,7 @@ class UpdatePreprint(object):
 
         else:
 
-            logger.info("Indexing in {0}".format(self.solr.url))
+            print("Indexing in {0}".format(self.solr.url))
 
             sickle = Sickle(self.args.oai_url, verify=False)
 
@@ -180,12 +133,12 @@ class UpdatePreprint(object):
                     xml = self.pipeline_to_xml(record.xml)
                     self.solr.update(xml, commit=True)
                 except ValueError as e:
-                    logger.error("ValueError: {0}".format(e))
-                    logger.exception(e)
+                    print("ValueError: {0}".format(e))
+                    print(e)
                     continue
                 except Exception as e:
-                    logger.error("Error: {0}".format(e))
-                    logger.exception(e)
+                    print("Error: {0}".format(e))
+                    print(e)
                     continue
 
         # optimize the index
@@ -208,7 +161,7 @@ def main():
         print("Duration {0} seconds.".format(end-start))
 
     except KeyboardInterrupt:
-        logger.critical("Interrupt by user")
+        print("Interrupt by user")
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Esse PR realiza além dos ajustes no IDs dos preprint realiza as seguintes correções no processamento: 

* Adiciona o pipeline de idiomas disponíveis.
* Adiciona msgs com os registro indexados.
* Altera o param -p para -t realiza o tratamento quando não existe registro no Servidor OAI
* Ajusta o ID dos documentos em preprint.
* Ajusta a execução dos testes.
* Remove a infraestrutura de logs.

Tíquete: https://github.com/scieloorg/search-journals/issues/501

Teste desse PR: 

```python 
python setup.py develop
python setup.py test
```

Com docker: 

Alterar o docker-compose-dev.yml:22 de **update_search_preprint -p 1** para **tail -f /dev/null**

Essa é uma forma de manter o container com um comando em **foreground**

No bash executar: 

```shell
docker-compose -f docker-compose-dev.yml up
doker exec -ti search-journals-proc_update-search-preprint_1 python setup.py test
```


