### PR TITLE
Adiciona mescla de documentos Solr (do tipo referência citada)

### DIFF
--- a/mergesearch/merge_solr.py
+++ b/mergesearch/merge_solr.py
@@ -37,6 +37,42 @@ class MergeSolr(object):
         with open(os.path.join('merges', filepath), 'w') as f:
             f.write(data)
 
+    def get_ids_for_merging(self, mongo_filter: dict):
+        """
+        Coleta identificadores da base de de-duplicação.
+
+        :param mongo_filter: Filtro Mongo para selecionar parte dos identificadores
+        :return: Identificadores hash das citações a serem mescladas
+        """
+        logging.info('Getting cited references identifiers... [filter=%s]' % mongo_filter)
+
+        ids_for_merging = []
+
+        for j in self.mongo.find(mongo_filter):
+
+            item = {
+                '_id': j['_id'],
+                'cit_full_ids': j['cit_full_ids'],
+                'citing_docs': j['citing_docs']
+            }
+
+            # Caso base de de-duplicação seja issue, mantem na citação principal o melhor valor de issue
+            if self.cit_hash_base == 'article_issue':
+                item.update({'cit_issue': j['cit_keys']['cleaned_issue']})
+
+            # Caso base de de-duplicação seja start_page, mantem na citação principal o melhor valor de start_page
+            if self.cit_hash_base == 'article_start_page':
+                item.update({'cit_start_page': j['cit_keys']['cleaned_start_page']})
+
+            # Caso base de de-duplicação seja volume, mantem na citação principal o melhor valor de volume
+            if self.cit_hash_base == 'article_volume':
+                item.update({'cit_volume': j['cit_keys']['cleaned_volume']})
+
+            ids_for_merging.append(item)
+
+        logging.info('There are %d cited references identifiers to be merged.' % len(ids_for_merging))
+
+        return ids_for_merging
     def persist(self, data, data_name):
         """
         Persiste data no disco e no Solr, se indicado.

--- a/mergesearch/merge_solr.py
+++ b/mergesearch/merge_solr.py
@@ -1,0 +1,26 @@
+import argparse
+import logging
+import os
+import SolrAPI
+import textwrap
+
+from datetime import datetime
+from pymongo import MongoClient, uri_parser
+
+SOLR_URL = os.environ.get('SOLR_URL', 'http://localhost:8983/solr/articles')
+SOLR_ROWS_LIMIT = os.environ.get('SOLR_ROWS_LIMIT', 10000)
+
+
+class MergeSolr(object):
+
+    def __init__(self,
+                 cit_hash_base,
+                 solr,
+                 mongo,
+                 persist_on_solr=False):
+
+        self.cit_hash_base = cit_hash_base
+        self.solr = solr
+        self.mongo = mongo
+        self.persist_on_solr = persist_on_solr
+

--- a/mergesearch/merge_solr.py
+++ b/mergesearch/merge_solr.py
@@ -149,6 +149,25 @@ class MergeSolr(object):
 
         return response
 
+    def mount_removing_commands(self, cits_for_removing):
+        """
+        Cria comandos para remoção de documentos Solr.
+
+        :param cits_for_removing: Identificadores de documentos a serem removidos
+        :return: Códigos Solr para remoção de documentos
+        """
+        rm_commands = []
+        ids = list(cits_for_removing)
+
+        for start_pos in range(0, len(ids), 1000):
+            last_pos = start_pos + 1000
+            if last_pos > len(ids):
+                last_pos = len(ids)
+
+            command = {'delete': {'query': 'id:(' + ' OR '.join([ids[k] for k in range(start_pos, last_pos)]) + ')'}}
+            rm_commands.append(command)
+        return rm_commands
+
     def persist(self, data, data_name):
         """
         Persiste data no disco e no Solr, se indicado.

--- a/mergesearch/merge_solr.py
+++ b/mergesearch/merge_solr.py
@@ -24,3 +24,28 @@ class MergeSolr(object):
         self.mongo = mongo
         self.persist_on_solr = persist_on_solr
 
+    def dump_data(self, data, filename):
+        """
+        Persiste dados no disco, em formato JSON
+
+        :param data: Dados a serem persistidos
+        :param filename: Nome do arquivo JSON
+        """
+        str_time = datetime.utcnow().isoformat(sep='_', timespec='milliseconds')
+        filepath = '-'.join([self.cit_hash_base, filename, str_time]) + '.json'
+
+        with open(os.path.join('merges', filepath), 'w') as f:
+            f.write(data)
+
+    def persist(self, data, data_name):
+        """
+        Persiste data no disco e no Solr, se indicado.
+
+        :param data: Dados a serem persistidos
+        :param data_name: Nome do conjunto de dados a ser persistido
+        """
+        self.dump_data(str(data), data_name)
+
+        if self.persist_on_solr:
+            self.solr.update(str(data).encode('utf-8'), headers={'content-type': 'application/json'})
+

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
     update_search_preprint=updatepreprint.updatepreprint:main
     update_search_accesses=updatesearch.accesses:main
     update_search_citations=updatesearch.citations:main
+    merge_search=mergesearch.merge_solr:main
     """
 )


### PR DESCRIPTION
## O que esse PR faz?

Adiciona script `merge_search` cujo objetivo é mesclar documentos Solr (do tipo referência citada, i.e., `entity="citation"`) que são semelhantes.


## Onde a revisão poderia começar?

Por commits.


## Como este poderia ser testado manualmente?

Criar ambiente virtual para python 3.6: `virtualenv -p python3.6 .venv`
Entrar no ambiente virtual criado: `source .venv/bin/activate`
Instalar dependências: `python setup.py install`
Exportar variável de ambiente com configuração Solr: `export SOLR_URL=http://localhost:8983/solr/articles` (também é possível usar o Solr em homologação, mas não recomendo)

Rodar comando para mesclar citações, no formato:

```
merge_search --mongo_ury [STRING_DE_CONEXÃO] --b [BASE_DE_DEDUPLICAÇÃO] --f [DATA_DE_ATUALIZAÇÃO]
```

O parâmetro STRING_DE_CONEXÃO refere-se a coleção MongoDB com a base de deduplicação a ser utilizada. Há cinco bases de de-duplicação (sugiro utilizar a primeira):

1. `dedup_article_issue`
2. `dedup_article_start_page`
3. `dedup_article_volume`
4. `dedup_book`
5. `dedup_chapter`

O parâmetro BASE_DE_DEDUPLICAÇÃO é o nome da base, sem o prefixo `dedup`. Ter os dois parâmetros é necessário pois teremos outras bases de de-duplicação (casamento aproximado).

O parâmetro DATA_DE_ATUALIZAÇÃO coletará as chaves na base de deduplicação cujo campo `update_date` é a partir da data informada. Como as bases de de-duplicação foram criadas num único dia, todos os registros possuem uma mesma data. Para possibilitar testes, forcei alguns registros para a data de hoje.

Um comando completo de exemplo é:

`merge_search --mongo_uri 'mongodb://localhost:27017/scielo_search.dedup_book' -b book -f 2020-07-09 -l INFO`


## Algum cenário de contexto que queira dar?

1. A mescla funciona acessando uma base Mongo que contenha IDs de referências citadas a serem mescladas. A base Mongo está disponível na própria estrutura SciELO (contactar-me). É possível ter uma cópia local.
2. É preciso ter um Solr funcionando (ou ter acesso ao Solr em homologação). 
3. **NÃO** use a opção `-s`, pois esta faz com que os dados sejam persistidos diretamente no Solr.
4. Arquivos JSON são criados para serem carregados no Solr (isso é mais rápido do que gravar diretamente nele)

### Como avaliar o resultado obtido?

1. Os arquivos JSON gerados são comandos Solr que podem ser carregados via `curl` ou via `simplepostjar`. Não é necessário fazer esse passo. Mas fazendo, é possível visualizar no search registros de citações com a informação "citado X vezes", em que `X > 1`.
2. Outra forma de avaliar é abrir os arquivos JSON e verificar se de fato há registros cujas listas de citações (campo `document_fk`) contém mais de um elemento (documentos citantes). Algo como:
    - `'document_fk': ['S0185-26982013000100004-mex', 'S0718-45652013000200004-chl', 'S1409-42582019000100158-cri', 'S1409-47032019000100078-cri', 'S1794-4724201300030000    4-col', 'S1409-47032017000100198-cri', 'S2448-76782016000100004-mex', 'S0122-82852008000100004-col']`


## Screenshots

N/A


## Quais são tickets relevantes?

[https://github.com/scieloorg/search-references-experiment/issues/41](https://github.com/scieloorg/search-references-experiment/issues/41)


## Referências
N/A