### PR TITLE
Adiciona novos acrônimos na lista de network na coleção Perú.

### DIFF
--- a/networks_config.json
+++ b/networks_config.json
@@ -14546,6 +14546,42 @@
     ]
   },
   {
+    "journal_acronym": "rcmhnaaa",
+    "in": [
+      "per"
+    ],
+    "networks": [
+      "org"
+    ]
+  },
+  {
+    "journal_acronym": "interac",
+    "in": [
+      "per"
+    ],
+    "networks": [
+      "org"
+    ]
+  },
+  {
+    "journal_acronym": "devenir",
+    "in": [
+      "per"
+    ],
+    "networks": [
+      "org"
+    ]
+  },
+  {
+    "journal_acronym": "contrat",
+    "in": [
+      "per"
+    ],
+    "networks": [
+      "org"
+    ]
+  },
+  {
     "journal_acronym": "ccv",
     "in": [
       "pry"


### PR DESCRIPTION
Novo acrônimo na lista de periódicos para a coleção Perú. 

Esse PR é motivado pela falta de periódico na lista completa do search quando contextualizado o Perú como coleção.


