### PR TITLE
Tk26 fix cleaned fields

### DIFF
--- a/updatesearch/pipeline_xml.py
+++ b/updatesearch/pipeline_xml.py
@@ -113,10 +113,16 @@ class Keywords(plumber.Pipe):
         for language, keywords in raw.keywords().items():
             for keyword in keywords:
                 field = ET.Element('field')
-                field.text = clean_text(keyword)
+                field.text = keyword
                 field.set('name', 'keyword_%s' % language)
-
                 xml.find('.').append(field)
+
+                cleaned = clean_text(keyword)
+                if cleaned:
+                    field = ET.Element('field')
+                    field.text = cleaned
+                    field.set('name', 'cleaned_keyword_%s' % language)
+                    xml.find('.').append(field)
 
         return data
 
@@ -342,7 +348,7 @@ class OriginalTitle(plumber.Pipe):
         raw, xml = data
 
         field = ET.Element('field')
-        field.text = clean_text(raw.original_title())
+        field.text = raw.original_title()
         field.set('name', 'ti')
         xml.find('.').append(field)
 
@@ -363,18 +369,32 @@ class Titles(plumber.Pipe):
         raw, xml = data
 
         field = ET.Element('field')
-        field.text = clean_text(raw.original_title())
+        field.text = raw.original_title()
         field.set('name', 'ti_%s' % raw.original_language())
         xml.find('.').append(field)
+
+        cleaned = clean_text(field.text)
+        if cleaned:
+            field = ET.Element('field')
+            field.text = cleaned
+            field.set('name', 'cleaned_ti_%s' % raw.original_language())
+            xml.find('.').append(field)
 
         if not raw.translated_titles():
             return data
 
         for language, title in raw.translated_titles().items():
             field = ET.Element('field')
-            field.text = clean_text(title)
+            field.text = title
             field.set('name', 'ti_%s' % language)
             xml.find('.').append(field)
+
+            cleaned = clean_text(title)
+            if cleaned:
+                field = ET.Element('field')
+                field.text = cleaned
+                field.set('name', 'cleaned_ti_%s' % language)
+                xml.find('.').append(field)
 
         return data
 
@@ -741,18 +761,32 @@ class Abstract(plumber.Pipe):
 
         if raw.original_abstract():
             field = ET.Element('field')
-            field.text = clean_text(raw.original_abstract())
+            field.text = raw.original_abstract()
             field.set('name', 'ab_%s' % raw.original_language())
             xml.find('.').append(field)
+
+            cleaned = clean_text(field.text)
+            if cleaned:
+                field = ET.Element('field')
+                field.text = cleaned
+                field.set('name', 'cleaned_ab_%s' % raw.original_language())
+                xml.find('.').append(field)
 
         if not raw.translated_abstracts():
             return data
 
         for language, abstract in raw.translated_abstracts().items():
             field = ET.Element('field')
-            field.text = clean_text(abstract)
+            field.text = abstract
             field.set('name', 'ab_%s' % language)
             xml.find('.').append(field)
+
+            cleaned = clean_text(abstract)
+            if cleaned:
+                field = ET.Element('field')
+                field.text = cleaned
+                field.set('name', 'cleaned_ab_%s' % language)
+                xml.find('.').append(field)
 
         return data
 

--- a/updatesearch/text_cleaner.py
+++ b/updatesearch/text_cleaner.py
@@ -1,7 +1,6 @@
 def clean_text(text):
     """
-    Retorna no início todas as strings encontradas em `text`,
-    seguidas de versões das strings que contém caracteres diferentes de letras,
+    Retorna versões das strings que contém caracteres diferentes de letras,
     por exemplo, no texto:
     '“Quem não se comunica se trumbica”: comportamento decisório e estratégias de autopromoção do Supremo Tribunal Federal1', as strings são:
     - “Quem
@@ -14,19 +13,20 @@ def clean_text(text):
     - trumbica”: se converte a trumbica” e trumbica
     - Federal1 se converte a Federal
 
-    Observe a entrada e a saída, que contém o texto inicial seguido das strings convertidas
+    Observe a entrada e a saída, que contém as strings convertidas
 
     In : clean_text('“Quem não se comunica se trumbica”: comportamento decisório e estratégias de autopromoção do Supremo Tribunal Federal1')
-    Out: '“Quem não se comunica se trumbica”: comportamento decisório e estratégias de autopromoção do Supremo Tribunal Federal1 Quem trumbica trumbica” Federal'
+    Out: 'trumbica Federal trumbica” Quem'
 
     """
     # mantém todas as str originais
     words = [w.strip() for w in text.split() if w.strip()]
 
-    # verifica se todas as str são alpha, retorna text original
+    # verifica se todas as str são alpha, retorna None
     if "".join(words).isalpha():
-        return text
+        return None
 
+    new_words = set()
     to_fix = _get_non_alpha_words(words)
     for word in to_fix:
 
@@ -37,13 +37,13 @@ def clean_text(text):
         for w in _fix_words(word):
             for part in w.split():
                 if part not in words:
-                    words.append(part)
+                    new_words.add(part)
 
         # obtém versão da str sem o caracter final se ele não for alpha e a adiciona se for inédita
         if word and not word[-1].isalpha():
             if word[:-1] and word[:-1] not in words:
-                words.append(word[:-1])
-    return " ".join(words)
+                new_words.add(word[:-1])
+    return " ".join(new_words)
 
 
 def _get_non_alpha_words(words):


### PR DESCRIPTION
#### O que esse PR faz?
Cria campos novos com prefixo `cleaned_` para títulos de artigo, palavras chaves e resumos

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```python

>>> from text_cleaner import clean_text
>>> clean_text('“Quem não se comunica se trumbica”: comportamento decisório e estratégias de autopromoção do Supremo Tribunal Federal1')
'Federal trumbica” trumbica Quem'
>>> clean_text('“Quem não se comunica se trumbica”: comportamento decisório e estratégias de autopromoção do Supremo Tribunal Federal')
'trumbica” trumbica Quem'
>>> clean_text('“Quem não se comunica se trumbica” comportamento decisório e estratégias de autopromoção do Supremo Tribunal Federal')
'trumbica Quem'
>>> clean_text('“Quem não se comunica se trumbica comportamento decisório e estratégias de autopromoção do Supremo Tribunal Federal')
'Quem'
>>> clean_text('Quem não se comunica se trumbica comportamento decisório e estratégias de autopromoção do Supremo Tribunal Federal')

```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#26

### Referências
n/a
