### PR TITLE
Add html pdf languages fields

### DIFF
--- a/tests/fixtures/article_meta.json
+++ b/tests/fixtures/article_meta.json
@@ -2770,6 +2770,7 @@
     "publication_year": "2010",
     "sent_wos": "True",
     "article": {
+        "fulltext_langs": {"html": ["en", "it", "jp"], "pdf": ["en", "do", "ru"]},
         "v30": [
             {
                 "_": "Rev. Sa\u00fade P\u00fablica"

--- a/tests/test_xmlpipeline.py
+++ b/tests/test_xmlpipeline.py
@@ -540,6 +540,68 @@ class ExportTests(unittest.TestCase):
 
         self.assertEqual(['en', 'es', 'pt'], sorted([i.text for i in result]))
 
+    def test_xml_document_html_languages_pipe(self):
+        
+        pxml = ET.Element('doc')
+        pxml.append(ET.Element('doc'))
+
+        data = [self._article_meta, pxml]
+
+        xmlarticle = pipeline_xml.HTMLLanguages()
+        raw, xml = xmlarticle.transform(data)
+
+        result = xml.findall('./field[@name="html_languages"]')
+
+        self.assertEqual(["en", "it", "jp"], sorted([i.text for i in result]))
+
+    def test_xml_document_html_languages_pipe_without_lanaguages(self):
+        
+        pxml = ET.Element('doc')
+        pxml.append(ET.Element('doc'))
+
+        # remove os idiomas
+        del self._article_meta.data["article"]["fulltext_langs"] 
+
+        data = [self._article_meta, pxml]
+
+        xmlarticle = pipeline_xml.HTMLLanguages()
+        raw, xml = xmlarticle.transform(data)
+
+        result = xml.findall('./field[@name="html_languages"]')
+
+        self.assertEqual([], sorted([i.text for i in result]))
+
+    def test_xml_document_pdf_languages_pipe(self):
+        
+        pxml = ET.Element('doc')
+        pxml.append(ET.Element('doc'))
+
+        data = [self._article_meta, pxml]
+
+        xmlarticle = pipeline_xml.PDFLanguages()
+        raw, xml = xmlarticle.transform(data)
+
+        result = xml.findall('./field[@name="pdf_languages"]')
+
+        self.assertEqual(['do', 'en', 'ru'], sorted([i.text for i in result]))
+
+    def test_xml_document_pdf_languages_pipe_without_lanaguages(self):
+        
+        pxml = ET.Element('doc')
+        pxml.append(ET.Element('doc'))
+
+        # remove os idiomas
+        del self._article_meta.data["article"]["fulltext_langs"] 
+
+        data = [self._article_meta, pxml]
+
+        xmlarticle = pipeline_xml.PDFLanguages()
+        raw, xml = xmlarticle.transform(data)
+
+        result = xml.findall('./field[@name="pdf_languages"]')
+
+        self.assertEqual([], sorted([i.text for i in result]))
+
     def test_xml_document_fulltexts_pipe(self):
 
         pxml = ET.Element('doc')

--- a/updatesearch/metadata.py
+++ b/updatesearch/metadata.py
@@ -80,6 +80,8 @@ class UpdateSearch(object):
             pipeline_xml.JournalAbbrevTitle(),
             pipeline_xml.Languages(),
             pipeline_xml.AvailableLanguages(),
+            pipeline_xml.HTMLLanguages(),
+            pipeline_xml.PDFLanguages(),
             pipeline_xml.Fulltexts(),
             pipeline_xml.PublicationDate(),
             pipeline_xml.SciELOPublicationDate(),

--- a/updatesearch/pipeline_xml.py
+++ b/updatesearch/pipeline_xml.py
@@ -636,6 +636,38 @@ class AvailableLanguages(plumber.Pipe):
             xml.find('.').append(field)
 
         return data
+class HTMLLanguages(plumber.Pipe):
+
+    def transform(self, data):
+        raw, xml = data
+
+        langs = []
+        if raw.data.get("article").get("fulltext_langs", []):
+            langs = raw.data.get("article").get("fulltext_langs").get("html")
+
+        for language in langs:
+            field = ET.Element('field')
+            field.text = language
+            field.set('name', 'html_languages')
+            xml.find('.').append(field)
+        
+        return data
+class PDFLanguages(plumber.Pipe):
+
+    def transform(self, data):
+        raw, xml = data
+
+        langs = []
+        if raw.data.get("article").get("fulltext_langs", []):
+            langs = raw.data.get("article").get("fulltext_langs").get("pdf")
+
+        for language in langs:
+            field = ET.Element('field')
+            field.text = language
+            field.set('name', 'pdf_languages')
+            xml.find('.').append(field)
+        
+        return data
 
 
 class Fulltexts(plumber.Pipe):


### PR DESCRIPTION
#### O que esse PR faz?
Add html pdf languages fields

#### Onde a revisão poderia começar?
por commit 

#### Como este poderia ser testado manualmente?
Para teste manual é necessário que seja executado o processamento localmente por exemplo:

```
python updatesearch/metadata.py -c dom
```

É possível também rodando os testes:

```
python -m unittest -v
```

#### Algum cenário de contexto que queira dar?

Foi adicionado esses novos campo para que não tenha impacto no campo **available_languages** já que é utilizado não somente para os campos de **html** e **pdf**, também é utilizado para a exibição do **abstract**, portanto não é possível alterar o campo **available_languages**, já que haveria impacto na construção dos links do abstract na interface do sistema de pesquisa, para comprovar o uso na interface do search do **available_languages**, veja: 

https://github.com/scieloorg/search-journals/blob/2c42b7232996568a86c65aa10595dc86518bfbd5/iahx/templates/custom/result-doc-actions.html#L5

Em consequência é necessário adiciona na interface do search.scielo.org a preferencia para esses novos campos e caso não existam, considera o campo **available_languages**

### Screenshots

<img width="1923" height="470" alt="Screenshot 2025-11-14 at 07 43 39" src="https://github.com/user-attachments/assets/96395a9d-0f1c-4c96-84d6-58a8ffe0ae4d" />



#### Quais são tickets relevantes?

#30 

### Referências
N/A
